### PR TITLE
Handling connection error

### DIFF
--- a/src/omise.js
+++ b/src/omise.js
@@ -13,19 +13,17 @@
   Omise.easyXDM = easyXDM.noConflict('Omise');
   Omise.easyXDM.DomHelper.requiresJSON(Omise._config.assetUrl + "/json2.js");
 
-  Omise._createRpc = function(handler){
+  Omise._createRpc = function(callback){
     if (Omise._rpc) {
       return Omise._rpc;
     } else {
       var tm = setTimeout(function() {
         Omise._rpc.destroy();
         Omise._rpc = null;
-        
-        if(handler){
-          handler(0, { code: "rpc_error", 
-                       message: "unable to connect to provider after 30 seconds" })
+        if(callback){
+          callback();
         }
-      },30000);
+      }, 30000);
       
       Omise._rpc = new Omise.easyXDM.Rpc({
         remote: Omise._config.vaultUrl + "/provider",
@@ -49,7 +47,12 @@
     var data = {};
     data[as] = attributes;
     
-    Omise._createRpc(handler).createToken(Omise.publicKey, data, function(response) {
+    Omise._createRpc(function(){
+      handler(0, { 
+        code: "rpc_error", 
+        message: "unable to connect to provider after timeout" 
+      });
+    }).createToken(Omise.publicKey, data, function(response) {
       handler(response.status, response.data);
     }, function(e){
       handler(e.data.status, e.data.data);

--- a/src/omise.js
+++ b/src/omise.js
@@ -13,7 +13,7 @@
   Omise.easyXDM = easyXDM.noConflict('Omise');
   Omise.easyXDM.DomHelper.requiresJSON(Omise._config.assetUrl + "/json2.js");
 
-  Omise._createRpc = function(callback){
+  Omise._createRpc = function(callback) {
     if (Omise._rpc) {
       return Omise._rpc;
     } else {
@@ -28,8 +28,8 @@
       Omise._rpc = new Omise.easyXDM.Rpc({
         remote: Omise._config.vaultUrl + "/provider",
         swf: Omise._config.assetUrl + "/easyxdm.swf",
-        onReady: function (){
-          clearTimeout(tm) 
+        onReady: function() {
+          clearTimeout(tm);
         }
       }, {remote: {createToken: {}}});
       return Omise._rpc;
@@ -47,7 +47,7 @@
     var data = {};
     data[as] = attributes;
     
-    Omise._createRpc(function(){
+    Omise._createRpc(function() {
       handler(0, { 
         code: "rpc_error", 
         message: "unable to connect to provider after timeout" 

--- a/src/omise.js
+++ b/src/omise.js
@@ -13,13 +13,26 @@
   Omise.easyXDM = easyXDM.noConflict('Omise');
   Omise.easyXDM.DomHelper.requiresJSON(Omise._config.assetUrl + "/json2.js");
 
-  Omise._createRpc = function(){
+  Omise._createRpc = function(handler){
     if (Omise._rpc) {
       return Omise._rpc;
     } else {
+      var tm = setTimeout(function() {
+        Omise._rpc.destroy();
+        Omise._rpc = null;
+        
+        if(handler){
+          handler(0, { code: "rpc_error", 
+                       message: "unable to connect to provider after 30 seconds" })
+        }
+      },30000);
+      
       Omise._rpc = new Omise.easyXDM.Rpc({
         remote: Omise._config.vaultUrl + "/provider",
-        swf: Omise._config.assetUrl + "/easyxdm.swf"
+        swf: Omise._config.assetUrl + "/easyxdm.swf",
+        onReady: function (){
+          clearTimeout(tm) 
+        }
       }, {remote: {createToken: {}}});
       return Omise._rpc;
     }
@@ -35,9 +48,12 @@
   Omise.createToken = function(as, attributes, handler) {
     var data = {};
     data[as] = attributes;
-    Omise._createRpc().createToken(Omise.publicKey, data, function(response) {
+    
+    Omise._createRpc(handler).createToken(Omise.publicKey, data, function(response) {
       handler(response.status, response.data);
-    }, function(){ /* noop */ });
+    }, function(e){
+      handler(e.data.status, e.data.data);
+    });
   };
 
   // exports


### PR DESCRIPTION
**1. Objective reason**

To be able to fire the error callback in case of connection to the xdm provider failure, this allows client to catch the error response and display appropriate message

**2. Description of change**

1. Implements the XHR onerror callback on xdm provider side (another PR on gateway repo) 
2. add new javascript timeout object (set to 30 seconds) as a workaround to detect that connection to XDM provider endpoint failed.
3. execute the client callback when xdm error happen on XDM provider side

**3. Developers affected by the change**

None

**4. Impact of the change**

None

**5. Priority of change**

Normal

**6. Alternate solution (if any)**

None