### PR TITLE
[HOTFIX] Fix missing typings folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ node_modules/
 jspm_packages/
 
 # Typescript v1 declaration files
-typings/
+# typings/
 
 # Optional npm cache directory
 .npm

--- a/typings/easyxdm.d.ts
+++ b/typings/easyxdm.d.ts
@@ -1,0 +1,27 @@
+declare interface EasyXDMDomHelper {
+  requiresJSON(path: string): void;
+}
+
+declare interface EasyXDM {
+  noConflict(name: string): EasyXDM;
+  DomHelper: EasyXDMDomHelper;
+  Rpc: EasyXDMRpc;
+}
+
+declare interface EasyXDMRpc {
+  new(transportConfig: EasyXDMTransportConfig, jsonRpcConfig: EasyXDMJsonRpcConfig): EasyXDMRpc
+  destroy(): void;
+  createToken(key: string, data: Object, onSuccess: Function, onError: Function): void;
+}
+
+declare interface EasyXDMTransportConfig {
+  remote: string;
+  swf: string;
+  onReady: () => void;
+}
+
+declare interface EasyXDMJsonRpcConfig {
+  remote: Object;
+}
+
+declare var easyXDM: EasyXDM;

--- a/typings/window.d.ts
+++ b/typings/window.d.ts
@@ -1,0 +1,4 @@
+declare interface Window {
+  Omise: any;
+  OmiseCard: any;
+}


### PR DESCRIPTION
**1. Objective reason**

Because `typings` folder are missing and I still don't know how to generate `typings` folders.
I decided to resolve this problem with simple way before find better solution than this.
**2. Description of change**

- Edit `.gitignore` to don't ignore `typings` folder.
- Add `typings` folder.

**3. Developers affected by the change**

None.

**4. Impact of the change**

None.

**5. Priority of change**

Normal.
