### PR TITLE
Disable loading easyxdm.swf

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Now you can view omise.js at `http://localhost:5001/omise.js` or insert Omise.js
 
 | NODE_ENV | CDN URL |
 | --- | --- |
-| `staging` | https://omise-cdn.s3.amazonaws.com/assets/omise-js-v2 |
+| `staging` | https://cdn.dev-omise.co |
 | `production` | https://cdn.omise.co |
 | `development`(default) | http://localhost:5002 |
 >if you not sure, please use `production`

--- a/bin/build-distribution.js
+++ b/bin/build-distribution.js
@@ -27,7 +27,7 @@ exec('npm run build', (err) => {
 
   let cdnUrl
   if (env === 'staging') {
-    cdnUrl = 'https://omise-cdn.s3.amazonaws.com/assets/omise-js-v2';
+    cdnUrl = 'https://cdn.dev-omise.co';
   } else if (env === 'production') {
     cdnUrl = 'https://cdn.omise.co';
   } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ratchagarn-omise.js",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "description": "New version of Omise.js",
   "main": "webpack.config.js",
   "scripts": {

--- a/src/Omise.js
+++ b/src/Omise.js
@@ -33,7 +33,6 @@ export default class Omise {
 
       this._rpc = new easyXDM.Rpc({
         remote: `${vaultUrl}/provider`,
-        swf: `${assetUrl}/easyxdm.swf`,
         onReady() {
           clearTimeout(tm);
         }

--- a/src/Omise.js
+++ b/src/Omise.js
@@ -23,7 +23,7 @@ export default class Omise {
       return this._rpc;
     }
     else {
-      const { vaultUrl, assetUrl } = this.config;
+      const { vaultUrl } = this.config;
       const tm = setTimeout(() => {
         this._rpc.destroy();
         this._rpc = null;
@@ -107,9 +107,6 @@ export function verifyConfigStructure(config) {
 
   if (!config.vaultUrl || !isUri(config.vaultUrl)) {
     result.message = 'Missing valutUrl';
-  }
-  else if (!config.assetUrl || !isUri(config.assetUrl)) {
-    result.message = 'Missing assetUrl';
   }
   else if (!config.cardHost || !isUri(config.cardHost)) {
     result.message = 'Missing cardHost';

--- a/src/config.js
+++ b/src/config.js
@@ -6,7 +6,6 @@
 
 const config = {
   vaultUrl: 'https://vault.omise.co',
-  assetUrl: 'http://localhost:5002',
   cardHost: 'http://localhost:5002',
   cardUrl:  'http://localhost:5002/pay.html',
   interfaceUrl: 'https://api.omise.co',

--- a/tests/Omise.spec.js
+++ b/tests/Omise.spec.js
@@ -16,16 +16,13 @@ describe('Omise.js', () => {
     expect(verifyConfigStructure({ vaultUrl: 'vaultUrl' }).error).toBeTruthy;
     expect(verifyConfigStructure({
       vaultUrl: 'vaultUrl',
-      assetUrl: 'assetUrl',
     }).error).toBeTruthy;
     expect(verifyConfigStructure({
       vaultUrl: 'vaultUrl',
-      assetUrl: 'assetUrl',
       cardHost: 'cardHost',
     }).error).toBeTruthy;
     expect(verifyConfigStructure({
       vaultUrl: 'vaultUrl',
-      assetUrl: 'assetUrl',
       cardHost: 'cardHost',
       cardUrl: 'cardUrl',
     }).error).toBeTruthy;


### PR DESCRIPTION
**1. Objective**

Disable FlashTransport to easyXDM.

**2. Description of change**

1.From the beginning, omise.js has been supported IE6/7 by using FlashTransport from easyXDM. but we didn't support FlashTransport anymore because IE6-8 cannot use Omise, since vault is TLS 1.2

So omise.js don't need to point this towards to `easyxdm.swf` file
2. Change omise.js url on staging environment
from
`https://omise-cdn.s3.amazonaws.com/assets/omise-js-v2`
to
`cdn.dev-omise.co`

**3. Quality assurance**

### Tested and compatibility
✅ Edge
✅ IE 9, 10, 11
✅ Google Chrome
✅ Firefox

**4. Operations impact**

None.

**5. Business impact**

None.

**6. Priority of change**

Normal


