### PR TITLE
Fix/unknown payment methods

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,5 @@
 {
   "baseUrl": "http://localhost:4126",
   "chromeWebSecurity": false,
-  "videoRecording": false
+  "video": false
 }

--- a/cypress/fixtures/default_method_with_apm.html
+++ b/cypress/fixtures/default_method_with_apm.html
@@ -1,26 +1,27 @@
 <html>
 <script type="text/javascript" src="http://localhost:5001/omise.js"></script>
+
 <body>
-    <form id="creditcardForm" name="checkoutForm" method="GET" action="checkout.php">
-      <input type='hidden' name="transaction_type_id" value="1" />
-      <input type='hidden' name="access_token" value="2" />
-      <button type="submit" id="checkout-button">บัตรเครดิต</button>
-    </form>
-    <script>
-      OmiseCard.configureButton('#checkout-button', {
-        submitFormTarget: "#creditcardForm",
-        defaultPaymentMethod: 'credit_card',
-        otherPaymentMethods: ['internet_banking', 'alipay'],
-        publicKey: 'pkey_test_59hx1kio6sjlocx8nbd',
-        amount: 2000,
-        currency: 'thb',
-        frameLabel: 'label',
-        frameDescription: 'descirption',
-        submitLabel: 'ชำระเงิน',
-        location: 'no'
-      });
-      OmiseCard.attach();
-    </script>
+  <form id="creditcardForm" name="checkoutForm" method="GET" action="checkout.php">
+    <input type='hidden' name="transaction_type_id" value="1" />
+    <input type='hidden' name="access_token" value="2" />
+    <button type="submit" id="checkout-button">บัตรเครดิต</button>
+  </form>
+  <script>
+    OmiseCard.configureButton('#checkout-button', {
+      submitFormTarget: "#creditcardForm",
+      defaultPaymentMethod: 'credit_card',
+      otherPaymentMethods: ['internet_banking', 'alipay'],
+      publicKey: 'pkey_test_5bgesov6ufhd884goy6',
+      amount: 2000,
+      currency: 'thb',
+      frameLabel: 'label',
+      frameDescription: 'descirption',
+      submitLabel: 'ชำระเงิน',
+      location: 'no'
+    });
+    OmiseCard.attach();
+  </script>
 
   </div>
 

--- a/cypress/fixtures/omiseCard_multi_form.html
+++ b/cypress/fixtures/omiseCard_multi_form.html
@@ -2,14 +2,12 @@
 
 <body>
   <form class="checkout-form" name="checkoutForm" method="GET" action="/checkout.php">
-    <script type="text/javascript" src="https://cdn.omise.co/omise.js" data-key="pkey_test_59hx1kio6sjlocx8nbd" data-amount="10025"
-      data-button-label="pre-built-button">
+    <script type="text/javascript" src="http://localhost:5001/omise.js" data-key="pkey_test_5bgesov6ufhd884goy6" data-amount="10025"
+      data-button-label="Click to see an example">
       </script>
-
   </form>
 
   <div class="row_pay_type">
-
     <form id="creditcardForm" name="checkoutForm" method="GET" action="card.php">
       <input type='hidden' name="transaction_type_id" value="1" />
       <input type='hidden' name="access_token" value="2" />
@@ -19,7 +17,7 @@
       OmiseCard.configureButton('#checkout-credit-card', {
         submitFormTarget: "#creditcardForm",
         defaultPaymentMethod: 'credit_card',
-        publicKey: 'pkey_test_59hx1kio6sjlocx8nbd',
+        publicKey: 'pkey_test_5bgesov6ufhd884goy6',
         amount: 2000,
         currency: 'thb',
         frameLabel: 'label',
@@ -31,7 +29,6 @@
   </div>
 
   <div class="row_pay_type">
-
     <form id="internetBankingForm" name="checkoutForm2" method="GET" action="banking.php">
       <input type='hidden' name="transaction_type_id" value="1" />
       <input type='hidden' name="access_token" value="2" />
@@ -41,7 +38,7 @@
       OmiseCard.configureButton('#checkout-internet-banking', {
         submitFormTarget: "#internetBankingForm",
         defaultPaymentMethod: 'internet_banking',
-        publicKey: 'pkey_test_59hx1kio6sjlocx8nbd',
+        publicKey: 'pkey_test_5bgesov6ufhd884goy6',
         amount: 2000,
         currency: 'thb',
         frameLabel: 'label',

--- a/cypress/fixtures/prebuilt.html
+++ b/cypress/fixtures/prebuilt.html
@@ -1,14 +1,12 @@
 <html>
-  <body>
-    <form class="checkout-form" name="checkoutForm" method="GET" action="/checkout.php">
-      <script type="text/javascript"
-        src="http://localhost:5001/omise.js"
-        data-key="pkey_test_59hx1kio6sjlocx8nbd"
-        data-amount="10025"
-        data-button-label="Click to see an example">
-      </script>
-    </form>
 
-  </body>
+<body>
+  <form class="checkout-form" name="checkoutForm" method="GET" action="/checkout.php">
+    <script type="text/javascript" src="http://localhost:5001/omise.js" data-key="pkey_test_5bgesov6ufhd884goy6" data-amount="10025"
+      data-button-label="Click to see an example">
+      </script>
+  </form>
+
+</body>
 
 </html>

--- a/cypress/fixtures/prebuilt_unknow_other_methods.html
+++ b/cypress/fixtures/prebuilt_unknow_other_methods.html
@@ -1,0 +1,12 @@
+<html>
+
+<body>
+  <form class="checkout-form" name="checkoutForm" method="GET" action="/checkout.php">
+    <script type="text/javascript" src="http://localhost:5001/omise.js" data-other-payment-methods="aaa" data-key="pkey_test_5bgesov6ufhd884goy6"
+      data-amount="10025" data-button-label="Click to see an example">
+      </script>
+  </form>
+
+</body>
+
+</html>

--- a/cypress/integration/omiseCard_spec.js
+++ b/cypress/integration/omiseCard_spec.js
@@ -1,69 +1,73 @@
 function checkoutCreditCard($body) {
+  cy.wrap($body).find('.OmiseCheckoutForm_container.open')
+
   cy.wrap($body)
-    .find('.OmiseCheckoutForm_container.open')
-  cy
-    .wrap($body)
     .find('input[name="cardNumber"]')
     .type('4111111111111111')
 
-  cy
-    .wrap($body)
+  cy.wrap($body)
     .find('input[name="nameOnCard"]')
     .type('John Doe')
 
-  cy
-    .wrap($body)
+  cy.wrap($body)
     .find('input[name="expiryDate"]')
     .type('10')
     .type('25')
 
-  cy
-    .wrap($body)
+  cy.wrap($body)
     .find('input[name="securityCode"]')
     .type('111')
 
-  cy
-    .wrap($body)
+  cy.wrap($body)
     .find('.OmiseCheckoutForm_checkoutButton button')
     .click()
 }
 
-describe('Omise Card', function () {
-  it('Should checkout by pre-built payment form', function () {
+describe('Omise Card', function() {
+  it('Should checkout by pre-built payment form', function() {
     cy.visit('/prebuilt.html')
     cy.get('button.omise-checkout-button').click()
-    cy.get('iframe#omise-checkout-iframe-app').then(($iframe) => {
+    cy.get('iframe#omise-checkout-iframe-app').then($iframe => {
       const $body = $iframe.contents().find('body')
-
+      console.log($body)
       checkoutCreditCard($body)
 
-      cy
-        .wrap($body)
-        .wait(3000)
+      cy.wrap($body).wait(3000)
 
-      cy
-        .url()
+      cy.url()
         .should('include', '/checkout.php')
         .should('include', 'omiseToken=tokn_test_')
     })
   })
 
-  context('multiple <form> tags with diffirent action url', () => {
+  it('Should checkout by pre-built payment form with unknown `data-other-payment-methods`', function() {
+    cy.visit('/prebuilt_unknow_other_methods.html')
+    cy.get('button.omise-checkout-button').click()
+    cy.get('iframe#omise-checkout-iframe-app').then($iframe => {
+      const $body = $iframe.contents().find('body')
+      cy.wrap($body)
+        .contains('Other Methods')
+        .click()
 
+      cy.wrap($body)
+        .find('.OmiseCheckoutForm_checkoutButton button')
+        .should('not.exist')
+    })
+  })
+
+  context('multiple <form> tags with diffirent action url', () => {
     it('Should checkout by pre-built payment form', () => {
       cy.visit('/omiseCard_multi_form.html')
       cy.get('button.omise-checkout-button').click()
-      cy.get('iframe#omise-checkout-iframe-app').then(($iframe) => {
+
+      cy.get('iframe#omise-checkout-iframe-app').then($iframe => {
         const $body = $iframe.contents().find('body')
 
         checkoutCreditCard($body)
 
-        cy
-          .wrap($body)
-          .wait(3000)
+        cy.wrap($body).wait(3000)
 
-        cy
-          .url()
+        cy.url()
           .should('include', '/checkout.php')
           .should('include', 'omiseToken=tokn_test_')
       })
@@ -72,17 +76,14 @@ describe('Omise Card', function () {
     it('Should checkout by OmiseCard.configureButton() and redirected to /card.php', () => {
       cy.visit('/omiseCard_multi_form.html')
       cy.get('button#checkout-credit-card').click()
-      cy.get('iframe#omise-checkout-iframe-app').then(($iframe) => {
+      cy.get('iframe#omise-checkout-iframe-app').then($iframe => {
         const $body = $iframe.contents().find('body')
 
         checkoutCreditCard($body)
 
-        cy
-          .wrap($body)
-          .wait(3000)
+        cy.wrap($body).wait(3000)
 
-        cy
-          .url()
+        cy.url()
           .should('include', '/card.php')
           .should('include', 'omiseToken=tokn_test_')
       })
@@ -91,24 +92,18 @@ describe('Omise Card', function () {
     it('Should checkout by OmiseCard.configureButton() and redirected to /banking.php', () => {
       cy.visit('/omiseCard_multi_form.html')
       cy.get('button#checkout-internet-banking').click()
-      cy.get('iframe#omise-checkout-iframe-app').then(($iframe) => {
+      cy.get('iframe#omise-checkout-iframe-app').then($iframe => {
         const $body = $iframe.contents().find('body')
 
-        cy
-          .wrap($body)
-          .find('.OmiseCheckoutForm_container.open')
+        cy.wrap($body).find('.OmiseCheckoutForm_container.open')
 
-        cy
-          .wrap($body)
+        cy.wrap($body)
           .contains('Bangkok Bank')
           .click()
 
-        cy
-          .wrap($body)
-          .wait(3000)
+        cy.wrap($body).wait(3000)
 
-        cy
-          .url()
+        cy.url()
           .should('include', '/banking.php')
           .should('include', 'omiseSource=src_test_')
       })
@@ -119,13 +114,12 @@ describe('Omise Card', function () {
     it('Should checkout by default payment method', () => {
       cy.visit('/default_method_with_apm.html')
       cy.get('button#checkout-button').click()
-      cy.get('iframe#omise-checkout-iframe-app').then(($iframe) => {
+      cy.get('iframe#omise-checkout-iframe-app').then($iframe => {
         const $body = $iframe.contents().find('body')
 
         checkoutCreditCard($body)
-  
-        cy
-          .url()
+
+        cy.url()
           .should('include', '/checkout.php')
           .should('include', 'omiseToken=tokn_test_')
       })
@@ -134,29 +128,22 @@ describe('Omise Card', function () {
     it('Should checkout by other payment methods', () => {
       cy.visit('/default_method_with_apm.html')
       cy.get('button#checkout-button').click()
-      cy.get('iframe#omise-checkout-iframe-app').then(($iframe) => {
+      cy.get('iframe#omise-checkout-iframe-app').then($iframe => {
         const $body = $iframe.contents().find('body')
 
-        cy
-          .wrap($body)
+        cy.wrap($body)
           .contains('Other Methods')
           .click()
 
-        cy
-          .wrap($body)
-          .contains('Alipay')
+        cy.wrap($body).contains('Alipay')
 
-        cy
-          .wrap($body)
+        cy.wrap($body)
           .contains('Bangkok Bank')
           .click()
 
-        cy
-          .wrap($body)
-          .wait(3000)
+        cy.wrap($body).wait(3000)
 
-        cy
-          .url()
+        cy.url()
           .should('include', '/checkout.php')
           .should('include', 'omiseSource=src_test_')
       })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,3 +23,10 @@
 //
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+Cypress.Commands.add('iframe', { prevSubject: 'element' }, $iframe => {
+  return new Cypress.Promise(resolve => {
+    $iframe.on('load', () => {
+      resolve($iframe.contents().find('body'))
+    })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "babel-preset-env": "^1.6.0",
     "chalk": "^2.0.1",
     "clean-webpack-plugin": "^0.1.9",
-    "cypress": "^2.0.4",
+    "cypress": "3.0.1",
     "eslint": "^3.10.2",
     "file-loader": "^0.8.5",
     "jest": "^20.0.4",

--- a/src/OmiseCard.js
+++ b/src/OmiseCard.js
@@ -309,8 +309,9 @@ export default class OmiseCard {
    * @param {Object} newConfig     - new config for merge with default config.
    * @return {Object} configure after merged and fix.
    */
-  prepareConfig(newConfig) {
+  prepareConfig(newConfig = {}) {
     const { otherPaymentMethods } = newConfig
+
     if (otherPaymentMethods && typeof otherPaymentMethods == 'string') {
       newConfig.otherPaymentMethods = this.stringToArray(otherPaymentMethods)
     }

--- a/src/OmiseCard.js
+++ b/src/OmiseCard.js
@@ -310,7 +310,16 @@ export default class OmiseCard {
    * @return {Object} configure after merged and fix.
    */
   prepareConfig(newConfig) {
+    const { otherPaymentMethods } = newConfig
+    if (otherPaymentMethods && typeof otherPaymentMethods == 'string') {
+      newConfig.otherPaymentMethods = this.stringToArray(otherPaymentMethods)
+    }
+
     return merge(this.app.defaultConfig, fixConfigName(newConfig))
+  }
+
+  stringToArray(str) {
+    return str.split(',').map(s => s.trim())
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,10 +11,11 @@
     date-fns "^1.27.2"
     figures "^1.7.0"
 
-"@cypress/xvfb@1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@cypress/xvfb/-/xvfb-1.1.3.tgz#6294a7d1feb751f12302248f2089fc534c4acb7f"
+"@cypress/xvfb@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@cypress/xvfb/-/xvfb-1.2.3.tgz#6319afdcdcff7d1505daeeaa84484d0596189860"
   dependencies:
+    debug "^3.1.0"
     lodash.once "^4.1.1"
 
 "@types/blob-util@1.3.3":
@@ -172,9 +173,15 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.0.0, ansi-styles@^3.1.0, ansi-styles@^3.2.0:
+ansi-styles@^3.0.0, ansi-styles@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
+  dependencies:
+    color-convert "^1.9.0"
+
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   dependencies:
     color-convert "^1.9.0"
 
@@ -1141,6 +1148,12 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+cachedir@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/cachedir/-/cachedir-1.2.0.tgz#e9a0a25bb21a2b7a0f766f07c41eb7a311919b97"
+  dependencies:
+    os-homedir "^1.0.1"
+
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
@@ -1189,13 +1202,13 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chalk@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
+chalk@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
-    ansi-styles "^3.1.0"
+    ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
-    supports-color "^4.0.0"
+    supports-color "^5.3.0"
 
 chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
@@ -1523,12 +1536,12 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-cypress@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-2.0.4.tgz#1d19eddc4bf5eb235a6327c60dd2deac2aad6ccd"
+cypress@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-3.0.1.tgz#6a8938ce8a551e4ae1bd5fb2ceab038d4ad39c4d"
   dependencies:
     "@cypress/listr-verbose-renderer" "0.4.1"
-    "@cypress/xvfb" "1.1.3"
+    "@cypress/xvfb" "1.2.3"
     "@types/blob-util" "1.3.3"
     "@types/bluebird" "3.5.18"
     "@types/chai" "4.0.8"
@@ -1540,11 +1553,13 @@ cypress@^2.0.4:
     "@types/sinon" "4.0.0"
     "@types/sinon-chai" "2.7.29"
     bluebird "3.5.0"
-    chalk "2.1.0"
+    cachedir "1.2.0"
+    chalk "2.4.1"
     check-more-types "2.24.0"
     commander "2.11.0"
     common-tags "1.4.0"
     debug "3.1.0"
+    executable "4.1.1"
     extract-zip "1.6.6"
     fs-extra "4.0.1"
     getos "2.8.4"
@@ -1554,6 +1569,7 @@ cypress@^2.0.4:
     lazy-ass "1.6.0"
     listr "0.12.0"
     lodash "4.17.4"
+    log-symbols "2.2.0"
     minimist "1.2.0"
     progress "1.1.8"
     ramda "0.24.1"
@@ -2020,6 +2036,12 @@ exec-sh@^0.2.0:
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.1.tgz#163b98a6e89e6b65b47c2a28d215bc1f63989c38"
   dependencies:
     merge "^1.1.3"
+
+executable@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/executable/-/executable-4.1.1.tgz#41532bff361d3e57af4d763b70582db18f5d133c"
+  dependencies:
+    pify "^2.2.0"
 
 exit-hook@^1.0.0:
   version "1.1.1"
@@ -2703,14 +2725,6 @@ http-signature@~1.2.0:
 https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
-
-husky@^0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
-  dependencies:
-    is-ci "^1.0.10"
-    normalize-path "^1.0.0"
-    strip-indent "^2.0.0"
 
 iconv-lite@0.4.19:
   version "0.4.19"
@@ -3619,6 +3633,12 @@ lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
+log-symbols@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
+  dependencies:
+    chalk "^2.0.1"
+
 log-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
@@ -3957,10 +3977,6 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
-normalize-path@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
-
 normalize-path@^2.0.0, normalize-path@^2.0.1, normalize-path@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
@@ -4090,7 +4106,7 @@ os-browserify@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
 
-os-homedir@^1.0.0:
+os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
@@ -4236,7 +4252,7 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
 
-pify@^2.0.0, pify@^2.3.0:
+pify@^2.0.0, pify@^2.2.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
@@ -5119,10 +5135,6 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
-strip-indent@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
-
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
@@ -5149,15 +5161,15 @@ supports-color@^3.1.0, supports-color@^3.1.2:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^4.0.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
-  dependencies:
-    has-flag "^2.0.0"
-
 supports-color@^5.1.0, supports-color@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.2.0.tgz#b0d5333b1184dd3666cbe5aa0b45c5ac7ac17a4a"
+  dependencies:
+    has-flag "^3.0.0"
+
+supports-color@^5.3.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
   dependencies:
     has-flag "^3.0.0"
 


### PR DESCRIPTION
## Problem 
Actually, `otherPaymentMethods ` is `Array` because it can set multiple methods likes `alipay, internet_banking` and send it to Pay.js. But when use in prebuilt from it was string and didn't convert to array, will get an error.
```
    <script type="text/javascript" src="http://localhost:5001/omise.js"
       data-other-payment-methods="unknown_method"
       data-key="pkey_test_"
       data-amount="10025"
       data-button-label="Click to see an example">
      </script>
```


## Solution
Alway convert from string to array for `otherPaymentMethods ` on `prepareConfig` function.


