### PR TITLE
[T7678] - Add hide amount default configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ratchagarn-omise.js",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "New version of Omise.js",
   "main": "webpack.config.js",
   "scripts": {

--- a/src/OmiseCard.js
+++ b/src/OmiseCard.js
@@ -33,7 +33,8 @@ export const defaultIframeAppConfig = {
   cardBrands: 'visa mastercard',
   locale: 'en', // en,th,ja
   autoCardNumberFormat: 'yes', // yes,no
-  expiryDateStyle: '', // basic
+  expiryDateStyle: '', // basic,
+  hideAmount: 'false', // false, true
 }
 
 export const iframeDefaultStyle = [

--- a/src/OmiseCard.js
+++ b/src/OmiseCard.js
@@ -33,7 +33,7 @@ export const defaultIframeAppConfig = {
   cardBrands: 'visa mastercard',
   locale: 'en', // en,th,ja
   autoCardNumberFormat: 'yes', // yes,no
-  expiryDateStyle: '', // basic,
+  expiryDateStyle: '', // basic
   hideAmount: 'false', // false, true
 }
 


### PR DESCRIPTION
**1. Objective**
This PR implements adds the default configuration for the functionality to hide the amount of the submit button label.

Related Link(s):
* [T7678](https://phabricator.omise.co/T7678)


**2. Description of change**
- *hideAmount* property was added to default configuration *defaultIframeAppConfig* in order

**3. Quality assurance**
- Use pay.js by providing configuration property as *data-hide-amount*=*"true"* from the PR([33](https://git.omise.co/omise/pay.js/pull/33))

**4. Operations impact**

- Run the *pay.js* by setting the *hideAmount* default configuration to "true"

**5. Business impact**

Some merchants just want to use Pre-built form for adding a customer, not to charge.

**6. Priority of change**
Normal

