### PR TITLE
Passes extra parameter `isSource` to `onCreateTokenSuccess`

### DIFF
--- a/src/OmiseCard.js
+++ b/src/OmiseCard.js
@@ -174,9 +174,10 @@ export default function OmiseCardFactory(settings, initWhenStart = true) {
       ..._app.defaultConfig,
       ..._app.currentOpenConfig
     };
+    const isSource = _isOmiseSource(token);
 
     if (_app.formElement) {
-      if (_isOmiseSource(token)) {
+      if (isSource) {
         _app.formElement.omiseSource.value = token;
       } else {
         _app.formElement.omiseToken.value = token;
@@ -186,8 +187,7 @@ export default function OmiseCardFactory(settings, initWhenStart = true) {
     if (submitAuto === 'yes' && _app.formElement) {
       _app.formElement.submit();
     }
-
-    (onCreateTokenSuccess || noop)(token); // TODO - return second param here for isSource
+    (onCreateTokenSuccess || noop)(token, isSource); 
 
     // clear current open config after submited
     _app.currentOpenConfig = {};


### PR DESCRIPTION
**1. Objective**

Currently it is necessary for the user to examine the string returned to `onCreateTokenSuccess` to determine if it is a Token or a Source ID. This PR introduces a further boolean parameter `isSource`. It is added at the end so that existing code will not break. 

**2. Description of change**

`setTokenAtOmiseTokenField` method modified to pass the additional param.

**3. Quality assurance**

Test with both a credit card payment, and another payment type to ensure the `isSource` param is being set correctly.

**4. Operations impact**

None
